### PR TITLE
Adding User Agent Header

### DIFF
--- a/ticker.sh
+++ b/ticker.sh
@@ -55,13 +55,16 @@ fi
 
 preflight () {
   curl --silent --output /dev/null --cookie-jar "$COOKIE_FILE" "https://finance.yahoo.com" \
-    -H "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"
+    -H "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8" \
+    -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36"
 }
 
 fetch_chart () {
   local symbol=$1
   local url="${API_ENDPOINT}${symbol}${API_SUFFIX}"
-  curl --silent -b "$COOKIE_FILE" "$url"
+  curl --silent -b "$COOKIE_FILE" \
+       -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36" \
+       "$url"
 }
 
 [ ! -f "$COOKIE_FILE" ] && preflight


### PR DESCRIPTION
Suddenly the Yahoo Endpoint want a user-agent header...

This pull request includes updates to the `ticker.sh` script to enhance HTTP request headers for better compatibility with the Yahoo Finance website.

Enhancements to HTTP request headers:

* [`ticker.sh`](diffhunk://#diff-d6d9dcb0171d87d0863a0e80d5402fc72a9a362b97c6f91527b491ee0f73fe6eL58-R67): Added a `User-Agent` header to the `preflight` function to mimic a modern web browser, ensuring successful cookie retrieval.
* [`ticker.sh`](diffhunk://#diff-d6d9dcb0171d87d0863a0e80d5402fc72a9a362b97c6f91527b491ee0f73fe6eL58-R67): Added a `User-Agent` header to the `fetch_chart` function to mimic a modern web browser, ensuring successful data fetching.