### PR TITLE
Keep Symbol Order

### DIFF
--- a/ticker.sh
+++ b/ticker.sh
@@ -103,7 +103,14 @@ if [ "$DISPLAY_METALS" = true ]; then
   fetch_metal_prices
 fi
 
-for symbol in "${SYMBOLS[@]}"; do
+# Array to hold temporary output file paths
+output_files=()
+
+for i in "${!SYMBOLS[@]}"; do
+  symbol="${SYMBOLS[$i]}"
+  tmp_output="${SESSION_DIR}/output_${i}.txt"
+  output_files[i]="$tmp_output"
+  
  (
   # Running in subshell 
   results=$(fetch_chart "$symbol")
@@ -128,17 +135,15 @@ for symbol in "${SYMBOLS[@]}"; do
     printf "%s%-10s%8.2f%10.2f%8s%6.2f%%%s\n" \
       "$color" "$symbol" \
       "$currentPrice" "$priceChange" "$color" "$percentChange" \
-      "$COLOR_RESET"
+      "$COLOR_RESET" > "$tmp_output"
   else
     printf "%-10s%8.2f%10.2f%9.2f%%\n" \
       "$symbol" \
-      "$currentPrice" "$priceChange" "$percentChange"
+      "$currentPrice" "$priceChange" "$percentChange" > "$tmp_output"
   fi 
  ) &
-
  # Stack PIDs
  pids+=($!)
-
 done
 
 # Wait for all background processes to finish
@@ -146,3 +151,7 @@ for pid in "${pids[@]}"; do
   wait "$pid"
 done
 
+# Print the results in the order of SYMBOLS
+for file in "${output_files[@]}"; do
+  cat "$file"
+done


### PR DESCRIPTION
added functionality per https://github.com/appatalks/ticker.sh/issues/4

#### Copilot Generated Summary

This pull request includes several changes to the `ticker.sh` script to improve the handling of temporary output files and ensure the results are printed in the correct order. The most important changes include the introduction of an array to hold temporary output file paths, modification of the printing logic to output to these files, and ensuring results are printed in the order of the symbols.

Improvements to temporary output file handling:

* [`ticker.sh`](diffhunk://#diff-d6d9dcb0171d87d0863a0e80d5402fc72a9a362b97c6f91527b491ee0f73fe6eL106-R113): Introduced `output_files` array to hold temporary output file paths. This change ensures that each symbol's output is stored in a separate file.

Modification of printing logic:

* [`ticker.sh`](diffhunk://#diff-d6d9dcb0171d87d0863a0e80d5402fc72a9a362b97c6f91527b491ee0f73fe6eL131-R157): Updated the `printf` statements to redirect output to the corresponding temporary output files. This ensures that the output for each symbol is captured correctly.

Ensuring correct order of results:

* [`ticker.sh`](diffhunk://#diff-d6d9dcb0171d87d0863a0e80d5402fc72a9a362b97c6f91527b491ee0f73fe6eL131-R157): Added a loop to print the contents of the temporary output files in the order of the symbols. This ensures that the final output is displayed in the correct order.